### PR TITLE
feat: copy licence into clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "tailwindcss": "^3.0.0",
         "tiny-emitter": "^2.1.0",
         "vue": "^3.2.31",
+        "vue-clipboard3": "^2.0.0",
         "vue-loader": "^17.0.0"
     }
 }

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -47,11 +47,11 @@ const logout = () => {
                                 </JetNavLink>
 
                                 <JetNavLink :href="route('officelife.index')" :active="route().current('officelife.index')">
-                                    OfficeLife's subscription
+                                    OfficeLife’s subscription
                                 </JetNavLink>
 
                                 <JetNavLink :href="route('monica.index')" :active="route().current('monica.index')">
-                                    Monica's subscription
+                                    Monica’s subscription
                                 </JetNavLink>
                             </div>
                         </div>
@@ -145,11 +145,11 @@ const logout = () => {
                         </JetResponsiveNavLink>
 
                         <JetResponsiveNavLink :href="route('officelife.index')" :active="route().current('officelife.index')">
-                            OfficeLife's subscription
+                            OfficeLife’s subscription
                         </JetResponsiveNavLink>
 
                         <JetResponsiveNavLink :href="route('monica.index')" :active="route().current('monica.index')">
-                            Monica's subscription
+                            Monica’s subscription
                         </JetResponsiveNavLink>
                     </div>
 

--- a/resources/js/Pages/Monica/Index.vue
+++ b/resources/js/Pages/Monica/Index.vue
@@ -1,5 +1,34 @@
-<style lang="scss" scoped>
-</style>
+<script setup>
+import { ref } from 'vue';
+import useClipboard from 'vue-clipboard3';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue';
+import JetActionMessage from '@/Jetstream/ActionMessage.vue';
+
+const props = defineProps({
+    data: Object,
+});
+
+const licence = ref(null);
+const copied = ref(false);
+const { toClipboard } = useClipboard();
+
+const select = () => {
+  licence.value.focus();
+  licence.value.select();
+}
+
+const copyIntoClipboard = async (text) => {
+    await toClipboard(text)
+    .then(() => {
+        copied.value = true;
+        setTimeout(() => {
+            copied.value = false;
+        }, 2000);
+    });
+};
+
+</script>
 
 <template>
    <AppLayout title="Monica’s Subscriptions">
@@ -17,14 +46,27 @@
           <div v-if="data.current_licence">
 
             <!-- case: active subscription -->
-            <div v-if="data.current_licence.subscription_state != 'subscription_cancelled'" class="mb-4 p-3 sm:p-3 w-full overflow-hidden bg-white px-6 py-6 shadow-md sm:rounded-lg">
+            <div v-if="data.current_licence.subscription_state !== 'subscription_cancelled'" class="mb-4 p-3 sm:p-3 w-full overflow-hidden bg-white px-6 py-6 shadow-md sm:rounded-lg">
               <p class="mb-6 text-center">🎉 You have an active subscription.</p>
 
-              <p class="mb-4">This is your licence key:
-                <span class="overflow-hidden w-full inline-block rounded bg-gray-200 px-3 py-2">
-                {{ data.current_licence.key }}
-                </span>
-              </p>
+              <div class="mb-4">
+                <div class="flex">
+                  <p class="flex-auto">
+                    This is your licence key:
+                  </p>
+                  <JetActionMessage :on="copied" class="mr-6">
+                      Copied!
+                  </JetActionMessage>
+                </div>
+
+                <div class="flex">
+                  <input class="truncate w-full inline-block rounded bg-gray-200 px-3 py-2 mr-3" :value="data.current_licence.key" ref="licence" type="text" @click.prevent="select" />
+                  <JetSecondaryButton title="Copy licence into your clipboard" @click.prevent="copyIntoClipboard(data.current_licence.key)">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" class="w-4 mr-1"><g transform="matrix(2.857142857142857,0,0,2.857142857142857,0,0)"><g><path d="M9.5,1.5H11a1,1,0,0,1,1,1v10a1,1,0,0,1-1,1H3a1,1,0,0,1-1-1V2.5a1,1,0,0,1,1-1H4.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path><rect x="4.5" y="0.5" width="5" height="2.5" rx="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></rect><line x1="4.5" y1="5.5" x2="9.5" y2="5.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><line x1="4.5" y1="8" x2="9.5" y2="8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><line x1="4.5" y1="10.5" x2="9.5" y2="10.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line></g></g></svg>
+                      Copy
+                  </JetSecondaryButton>
+                </div>
+              </div>
 
               <div class="mb-4 bg-blue-100 flex rounded-lg p-4">
                 <div>
@@ -128,20 +170,3 @@
       </div>
    </AppLayout>
 </template>
-
-<script>
-import AppLayout from '@/Layouts/AppLayout.vue';
-
-export default {
-  components: {
-    AppLayout,
-  },
-
-  props: {
-    data: {
-      type: Object,
-      default: null,
-    },
-  }
-};
-</script>

--- a/resources/js/Pages/Monica/Index.vue
+++ b/resources/js/Pages/Monica/Index.vue
@@ -1,9 +1,7 @@
 <script setup>
 import { onMounted, onUnmounted, ref } from 'vue';
-import useClipboard from 'vue-clipboard3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue';
-import JetActionMessage from '@/Jetstream/ActionMessage.vue';
+import LicenceDisplay from '@/Pages/Partials/LicenceDisplay.vue';
 
 const props = defineProps({
     data: Object,
@@ -11,10 +9,6 @@ const props = defineProps({
 });
 
 const refresh = ref(_.debounce(() => doRefresh(), 1000));
-
-const licence = ref(null);
-const copied = ref(false);
-const { toClipboard } = useClipboard();
 
 onMounted(() => {
     if (props.refresh) {
@@ -39,21 +33,6 @@ const doRefresh = () => {
     }
 };
 
-const select = () => {
-  licence.value.focus();
-  licence.value.select();
-}
-
-const copyIntoClipboard = async (text) => {
-    await toClipboard(text)
-    .then(() => {
-        copied.value = true;
-        setTimeout(() => {
-            copied.value = false;
-        }, 2000);
-    });
-};
-
 </script>
 
 <template>
@@ -65,7 +44,7 @@ const copyIntoClipboard = async (text) => {
             <img loading="lazy" src="/img/monica-logo.svg" alt="officelife logo" class="mb-3 mx-auto" height="150"
                   width="150"
             />
-            <p class="text-sm">Monica is a great open source personal CRM. Monica allows people to keep track of everything that’s important about their friends and family. <a href="https://monicahq.com" class="underline">https://monicahq.com</a></p>
+            <p class="text-sm">Monica is a great open source personal CRM. Monica allows people to keep track of everything that’s important about their friends and family. <a href="https://monicahq.com" rel="noopener noreferrer" class="underline">https://monicahq.com</a></p>
           </div>
 
           <!-- current licence, if defined -->
@@ -73,64 +52,7 @@ const copyIntoClipboard = async (text) => {
 
             <!-- case: active subscription -->
             <div v-if="data.current_licence.subscription_state !== 'subscription_cancelled'" class="mb-4 p-3 sm:p-3 w-full overflow-hidden bg-white px-6 py-6 shadow-md sm:rounded-lg">
-              <p class="mb-6 text-center">🎉 You have an active subscription.</p>
-
-              <div class="mb-4">
-                <div class="flex">
-                  <p class="flex-auto">
-                    This is your licence key:
-                  </p>
-                  <JetActionMessage :on="copied" class="mr-6">
-                      Copied!
-                  </JetActionMessage>
-                </div>
-
-                <div class="flex">
-                  <input class="truncate w-full inline-block rounded bg-gray-200 px-3 py-2 mr-3" :value="data.current_licence.key" ref="licence" type="text" @click.prevent="select" />
-                  <JetSecondaryButton title="Copy licence into your clipboard" @click.prevent="copyIntoClipboard(data.current_licence.key)">
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" class="w-4 mr-1"><g transform="matrix(2.857142857142857,0,0,2.857142857142857,0,0)"><g><path d="M9.5,1.5H11a1,1,0,0,1,1,1v10a1,1,0,0,1-1,1H3a1,1,0,0,1-1-1V2.5a1,1,0,0,1,1-1H4.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path><rect x="4.5" y="0.5" width="5" height="2.5" rx="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></rect><line x1="4.5" y1="5.5" x2="9.5" y2="5.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><line x1="4.5" y1="8" x2="9.5" y2="8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><line x1="4.5" y1="10.5" x2="9.5" y2="10.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line></g></g></svg>
-                      Copy
-                  </JetSecondaryButton>
-                </div>
-              </div>
-
-              <div class="mb-4 bg-blue-100 flex rounded-lg p-4">
-                <div>
-                  <p class="font-bold mb-2">How to use your key:</p>
-                  <ul class="ml-4">
-                    <li><span class="text-blue-500">1. </span>  Go to <a href="https://app.monicahq.com/settings/billing" class="underline">https://app.monicahq.com/settings/billing</a></li>
-                    <li><span class="text-blue-500">2. </span>  Locate the Licence key section</li>
-                    <li><span class="text-blue-500">3. </span>  Paste the licence key shown above.</li>
-                    <li><span class="text-blue-500">4. </span>  Enjoy!</li>
-                  </ul>
-                </div>
-              </div>
-
-              <p class="mb-4 flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                </svg>
-                The licence key will automatically renew on {{ data.current_licence.valid_until_at }}.
-              </p>
-
-              <p>
-
-                <a :href="data.current_licence.paddle_update_url" class="mr-2 cursor-pointer focus:shadow-outline-gray inline-flex items-center rounded-md border border-transparent bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:border-gray-900 focus:outline-none active:bg-gray-900">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                  </svg>
-
-                  Update payment details
-                </a>
-
-                <a :href="data.current_licence.paddle_cancel_url" class="cursor-pointer focus:shadow-outline-gray inline-flex items-center rounded-md border border-transparent bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:border-gray-900 focus:outline-none active:bg-gray-900">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-
-                  Stop
-                </a>
-              </p>
+              <LicenceDisplay :licence="data.current_licence" :url="'https://app.monicahq.com/settings/billing'" />
             </div>
 
             <!-- case: cancelled subscription -->
@@ -155,7 +77,7 @@ const copyIntoClipboard = async (text) => {
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-1 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
                     </svg>
-                    Secure payment by <a href="https://paddle.com" class="ml-1">Paddle</a>
+                    Secure payment by <a href="https://paddle.com" rel="noopener noreferrer" target="_blank" class="ml-1">Paddle</a>
                   </p>
                 </div>
               </div>
@@ -178,7 +100,7 @@ const copyIntoClipboard = async (text) => {
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-1 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
                   </svg>
-                  Secure payment by <a href="https://paddle.com" class="ml-1">Paddle</a>
+                  Secure payment by <a href="https://paddle.com" rel="noopener noreferrer" target="_blank" class="ml-1">Paddle</a>
                 </p>
               </div>
             </div>
@@ -188,8 +110,8 @@ const copyIntoClipboard = async (text) => {
 
           <p class="text-gray-6 mt-8 mb-10">
             It might take a few seconds for your subscription to be processed.
-            Refresh this page once you've subscribed to see your licence key.
-            If you experience issues after purchase, please contact us at support@monicahq.com.
+            Refresh this page once you’ve subscribed to see your licence key.
+            If you experience issues after purchase, please contact us at <a href="mailto:support@monicahq.com">support@monicahq.com</a>.
           </p>
 
         </div>

--- a/resources/js/Pages/OfficeLife/Index.vue
+++ b/resources/js/Pages/OfficeLife/Index.vue
@@ -1,9 +1,6 @@
 <script setup>
 import { onMounted, onUnmounted, ref } from 'vue';
-import useClipboard from 'vue-clipboard3';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue';
-import JetActionMessage from '@/Jetstream/ActionMessage.vue';
 import LicenceDisplay from '@/Pages/Partials/LicenceDisplay.vue';
 
 const props = defineProps({

--- a/resources/js/Pages/OfficeLife/Index.vue
+++ b/resources/js/Pages/OfficeLife/Index.vue
@@ -4,6 +4,7 @@ import useClipboard from 'vue-clipboard3';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue';
 import JetActionMessage from '@/Jetstream/ActionMessage.vue';
+import LicenceDisplay from '@/Pages/Partials/LicenceDisplay.vue';
 
 const props = defineProps({
     data: Object,
@@ -11,12 +12,7 @@ const props = defineProps({
 });
 
 const localPlans = ref([]);
-
 const refresh = ref(_.debounce(() => doRefresh(), 1000));
-
-const licence = ref(null);
-const copied = ref(false);
-const { toClipboard } = useClipboard();
 
 onMounted(() => {
     localPlans.value = props.data.plans;
@@ -42,21 +38,6 @@ const doRefresh = () => {
     }
 };
 
-const select = () => {
-  licence.value.focus();
-  licence.value.select();
-}
-
-const copyIntoClipboard = async (text) => {
-    await toClipboard(text)
-      .then(() => {
-          copied.value = true;
-          setTimeout(() => {
-              copied.value = false;
-          }, 2000);
-      });
-};
-
 const checkPrice = (plan) => {
     axios.post(plan.url.price, { quantity: plan.quantity })
         .then((response) => {
@@ -76,7 +57,7 @@ const checkPrice = (plan) => {
             <img loading="lazy" src="/img/officelife-logo.svg" alt="officelife logo" class="mb-3 mx-auto" height="150"
                   width="150"
             />
-            <p class="text-sm">OfficeLife is an Employee Operation plateform. It manages everything employees do in a company. From projects to holidays to 1:1s to teams. <a href="https://officelife.io" class="underline">https://officelife.io</a></p>
+            <p class="text-sm">OfficeLife is an Employee Operation plateform. It manages everything employees do in a company. From projects to holidays to 1:1s to teams. <a href="https://officelife.io" rel="noopener noreferrer" class="underline">https://officelife.io</a></p>
           </div>
 
           <!-- current licence, if defined -->
@@ -84,63 +65,7 @@ const checkPrice = (plan) => {
 
             <!-- case: active subscription -->
             <div v-if="data.current_licence.subscription_state !== 'subscription_cancelled'" class="mb-4 p-3 sm:p-3 w-full overflow-hidden bg-white px-6 py-6 shadow-md sm:rounded-lg">
-              <p class="mb-6 text-center">🎉 You have an active subscription.</p>
-
-              <div class="mb-4">
-                <div class="flex">
-                  <p class="flex-auto">
-                    This is your licence key:
-                  </p>
-                  <JetActionMessage :on="copied" class="mr-6">
-                      Copied!
-                  </JetActionMessage>
-                </div>
-
-                <div class="flex">
-                  <input class="truncate w-full inline-block rounded bg-gray-200 px-3 py-2 mr-3" :value="data.current_licence.key" ref="licence" type="text" @click.prevent="select" />
-                  <JetSecondaryButton title="Copy licence into your clipboard" @click.prevent="copyIntoClipboard(data.current_licence.key)">
-                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" class="w-4 mr-1"><g transform="matrix(2.857142857142857,0,0,2.857142857142857,0,0)"><g><path d="M9.5,1.5H11a1,1,0,0,1,1,1v10a1,1,0,0,1-1,1H3a1,1,0,0,1-1-1V2.5a1,1,0,0,1,1-1H4.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path><rect x="4.5" y="0.5" width="5" height="2.5" rx="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></rect><line x1="4.5" y1="5.5" x2="9.5" y2="5.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><line x1="4.5" y1="8" x2="9.5" y2="8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><line x1="4.5" y1="10.5" x2="9.5" y2="10.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line></g></g></svg>
-                      Copy
-                  </JetSecondaryButton>
-                </div>
-              </div>
-
-              <div class="mb-4 bg-blue-100 flex rounded-lg p-4">
-                <div>
-                  <p class="font-bold mb-2">How to use your key:</p>
-                  <ul class="ml-4">
-                    <li><span class="text-blue-500">1. </span>  Go to <a href="https://app.monicahq.com/settings/billing" class="underline">https://app.monicahq.com/settings/billing</a></li>
-                    <li><span class="text-blue-500">2. </span>  Locate the Licence key section</li>
-                    <li><span class="text-blue-500">3. </span>  Paste the licence key shown above.</li>
-                    <li><span class="text-blue-500">4. </span>  Enjoy!</li>
-                  </ul>
-                </div>
-              </div>
-
-              <p class="mb-4 flex items-center">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                </svg>
-                The licence key will automatically renew on {{ data.current_licence.valid_until_at }}.
-              </p>
-
-              <p>
-                <a :href="data.current_licence.paddle_update_url" class="mr-2 cursor-pointer focus:shadow-outline-gray inline-flex items-center rounded-md border border-transparent bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:border-gray-900 focus:outline-none active:bg-gray-900">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                  </svg>
-
-                  Update payment details
-                </a>
-
-                <a :href="data.current_licence.paddle_cancel_url" class="cursor-pointer focus:shadow-outline-gray inline-flex items-center rounded-md border border-transparent bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:border-gray-900 focus:outline-none active:bg-gray-900">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-
-                  Stop
-                </a>
-              </p>
+              <LicenceDisplay :licence="data.current_licence" :url="'https://app.officelife.io/settings/billing'" />
             </div>
 
             <!-- case: cancelled subscription -->
@@ -165,7 +90,7 @@ const checkPrice = (plan) => {
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-1 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
                     </svg>
-                    Secure payment by <a href="https://paddle.com" class="ml-1">Paddle</a>
+                    Secure payment by <a href="https://paddle.com" rel="noopener noreferrer" target="_blank" class="ml-1">Paddle</a>
                   </p>
                 </div>
               </div>
@@ -204,7 +129,7 @@ const checkPrice = (plan) => {
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-1 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
                     </svg>
-                    Secure payment by <a href="https://paddle.com" class="ml-1">Paddle</a>
+                    Secure payment by <a href="https://paddle.com" rel="noopener noreferrer" target="_blank" class="ml-1">Paddle</a>
                   </p>
                 </div>
               </div>
@@ -213,8 +138,8 @@ const checkPrice = (plan) => {
 
           <p class="text-gray-6 mt-8 mb-10">
             It might take a few seconds for your subscription to be processed.
-            Refresh this page once you've subscribed to see your licence key.
-            If you experience issues after purchase, please contact us at support@monicahq.com.
+            Refresh this page once you’ve subscribed to see your licence key.
+            If you experience issues after purchase, please contact us at <a href="mailto:support@officelife.io">support@officelife.io</a>.
           </p>
 
         </div>

--- a/resources/js/Pages/Partials/LicenceDisplay.vue
+++ b/resources/js/Pages/Partials/LicenceDisplay.vue
@@ -1,0 +1,94 @@
+<script setup>
+import { ref } from 'vue';
+import useClipboard from 'vue-clipboard3';
+import JetSecondaryButton from '@/Jetstream/SecondaryButton.vue';
+import JetActionMessage from '@/Jetstream/ActionMessage.vue';
+
+const props = defineProps({
+    licence: Object,
+    url: String,
+});
+
+const licenceInput = ref(null);
+const copied = ref(false);
+const { toClipboard } = useClipboard();
+
+const select = () => {
+  licenceInput.value.focus();
+  licenceInput.value.select();
+}
+
+const copyIntoClipboard = async (text) => {
+    await toClipboard(text)
+    .then(() => {
+        copied.value = true;
+        setTimeout(() => {
+            copied.value = false;
+        }, 2000);
+    });
+};
+
+</script>
+
+<template>
+  <div>
+    <p class="mb-6 text-center">🎉 You have an active subscription.</p>
+
+    <div class="mb-4">
+      <div class="flex">
+        <p class="flex-auto">
+          This is your licence key:
+        </p>
+        <JetActionMessage :on="copied" class="mr-6">
+            Copied!
+        </JetActionMessage>
+      </div>
+
+      <div class="flex">
+        <input class="truncate w-full inline-block rounded bg-gray-200 px-3 py-2 mr-3" :value="licence.key" ref="licenceInput" type="text" @click.prevent="select" />
+        <JetSecondaryButton title="Copy licence into your clipboard" @click.prevent="copyIntoClipboard(licence.key)">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" class="w-4 mr-1"><g transform="matrix(2.857142857142857,0,0,2.857142857142857,0,0)"><g><path d="M9.5,1.5H11a1,1,0,0,1,1,1v10a1,1,0,0,1-1,1H3a1,1,0,0,1-1-1V2.5a1,1,0,0,1,1-1H4.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path><rect x="4.5" y="0.5" width="5" height="2.5" rx="1" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></rect><line x1="4.5" y1="5.5" x2="9.5" y2="5.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><line x1="4.5" y1="8" x2="9.5" y2="8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line><line x1="4.5" y1="10.5" x2="9.5" y2="10.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></line></g></g></svg>
+            Copy
+        </JetSecondaryButton>
+      </div>
+    </div>
+
+    <div class="mb-4 bg-blue-100 flex rounded-lg p-4">
+      <div>
+        <p class="font-bold mb-2">How to use your key:</p>
+        <ul class="ml-4">
+          <li><span class="text-blue-500">1. </span>  Go to <a :href="url" rel="noopener noreferrer" target="_blank" class="underline">{{ url }}</a></li>
+          <li><span class="text-blue-500">2. </span>  Locate the Licence key section</li>
+          <li><span class="text-blue-500">3. </span>  Paste the licence key shown above.</li>
+          <li><span class="text-blue-500">4. </span>  Enjoy!</li>
+        </ul>
+      </div>
+    </div>
+
+    <p class="mb-4 flex items-center">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+      </svg>
+      The licence key will automatically renew on {{ licence.valid_until_at }}.
+    </p>
+
+    <p>
+
+      <a :href="licence.paddle_update_url" rel="noopener noreferrer" class="mr-2 cursor-pointer focus:shadow-outline-gray inline-flex items-center rounded-md border border-transparent bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:border-gray-900 focus:outline-none active:bg-gray-900">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+        </svg>
+
+        Update payment details
+      </a>
+
+      <a :href="licence.paddle_cancel_url" rel="noopener noreferrer" class="cursor-pointer focus:shadow-outline-gray inline-flex items-center rounded-md border border-transparent bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:border-gray-900 focus:outline-none active:bg-gray-900">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 inline mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+
+        Stop
+      </a>
+    </p>
+  </div>
+</template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2033,6 +2033,15 @@ cli-table3@^0.6.0:
   optionalDependencies:
     colors "1.4.0"
 
+clipboard@^2.0.6:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.11.tgz#62180360b97dd668b6b3a84ec226975762a70be5"
+  integrity sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -2470,6 +2479,11 @@ del@^6.0.0:
     p-map "^4.0.0"
     rimraf "^3.0.2"
     slash "^3.0.0"
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -3025,6 +3039,13 @@ globby@^11.0.1:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.9"
@@ -4923,6 +4944,11 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==
+
 selfsigned@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.0.0.tgz#e927cd5377cbb0a1075302cff8df1042cc2bce5b"
@@ -5342,7 +5368,7 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-emitter@^2.1.0:
+tiny-emitter@^2.0.0, tiny-emitter@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
@@ -5473,6 +5499,13 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vue-clipboard3@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vue-clipboard3/-/vue-clipboard3-2.0.0.tgz#79b026c765c0f6a5cde18a477c2dbfc7d3b9f178"
+  integrity sha512-Q9S7dzWGax7LN5iiSPcu/K1GGm2gcBBlYwmMsUc5/16N6w90cbKow3FnPmPs95sungns4yvd9/+JhbAznECS2A==
+  dependencies:
+    clipboard "^2.0.6"
 
 vue-loader@^17.0.0:
   version "17.0.0"


### PR DESCRIPTION
- add a button to copy the licence into clipboard
- also change the licence text behavior to select the complete licence text. Without that, the trailing '=' characters might be missing from the copy/paste.

![image](https://user-images.githubusercontent.com/25419741/173134006-98db53c1-f7b0-4f8a-b5c0-0f870e227129.png)
