### PR TITLE
chore: remove next_check_at from the licence key

### DIFF
--- a/app/Http/Controllers/ValidateKeyController.php
+++ b/app/Http/Controllers/ValidateKeyController.php
@@ -8,7 +8,7 @@ use Exception;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 
-class ValidationController extends Controller
+class ValidateKeyController extends Controller
 {
     public function index(Request $request)
     {

--- a/app/Services/CreateLicenceKey.php
+++ b/app/Services/CreateLicenceKey.php
@@ -65,7 +65,6 @@ class CreateLicenceKey
         return [
             'frequency' => $price['frequency'],
             'purchaser_email' => $this->user->email,
-            'next_check_at' => $this->nextDate->format('Y-m-d'),
         ];
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,19 +1,8 @@
 <?php
 
-use App\Http\Controllers\ValidationController;
+use App\Http\Controllers\ValidateKeyController;
 use Illuminate\Support\Facades\Route;
 
-/*
-|--------------------------------------------------------------------------
-| API Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register API routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| is assigned the "api" middleware group. Enjoy building your API!
-|
-*/
-
-Route::post('validate', [ValidationController::class, 'index'])
+Route::post('validate', [ValidateKeyController::class, 'index'])
     ->middleware(['client:manage-key'])
     ->name('validation.index');

--- a/tests/Unit/Services/CreateLicenceKeyTest.php
+++ b/tests/Unit/Services/CreateLicenceKeyTest.php
@@ -55,15 +55,10 @@ class CreateLicenceKeyTest extends TestCase
 
         $this->assertArrayHasKey('frequency', $array);
         $this->assertArrayHasKey('purchaser_email', $array);
-        $this->assertArrayHasKey('next_check_at', $array);
 
         $this->assertEquals(
             'regis@monicahq.com',
             $array['purchaser_email']
-        );
-        $this->assertEquals(
-            '2022-04-02',
-            $array['next_check_at']
         );
         $this->assertEquals(
             'month',


### PR DESCRIPTION
We remove the `next_check_at` entry in the licence key itself. This information is not needed.